### PR TITLE
feat: add -c option to scan all folders from syncthing config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,22 @@ instead, consent is asked for removal:
 (C) + syncthing-resolve-conflicts -h
 syncthing-resolve-conflicts v1.2.0
 
-Inspired by 'pacdiff'. A simple program to merge or remove sync conflicts.
-'locate' (or 'find', see -f option) is used to find conflicts. In case the
-database is not recent, run 'updatedb'.
+Inspired by 'pacdiff'. A simple program to merge or remove synchronization
+conflicts. 'locate' (or 'find' or 'fd', see -f and -F options) is used to
+find conflicts. If you are using 'locate', make sure that your database is
+up-to-date by running 'updatedb'.
 
-Usage: syncthing-resolve-conflicts [-d DIR] [-f] [-o] [--nocolor]
+Usage: syncthing-resolve-conflicts [-c] [-d DIR] [-f] [-F] [-o] [--nocolor]
 
 General Options:
+  -c/--config         scan all folders from the syncthing configuration;
+                      config location is taken from $STCONFDIR or $STHOMEDIR,
+                      then 'syncthing paths', then the platform default
   -d/--directory DIR  only scan for sync conflicts in the directory DIR
   -f/--find           use find instead of locate; by default, scan the home
+                      directory of the current user, but please see the -d
+                      option
+  -F/--fd             use fd instead of locate; by default, scan the home
                       directory of the current user, but please see the -d
                       option
   -o/--output         print files instead of merging them

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ conflicts. 'locate' (or 'find' or 'fd', see -f and -F options) is used to
 find conflicts. If you are using 'locate', make sure that your database is
 up-to-date by running 'updatedb'.
 
-Usage: syncthing-resolve-conflicts [-c] [-d DIR] [-f] [-F] [-o] [--nocolor]
+Usage: syncthing-resolve-conflicts [-d DIR] [-c] [-f] [-F] [-o] [--nocolor]
 
 General Options:
+  -d/--directory DIR  only scan for sync conflicts in the directory DIR
   -c/--config         scan all folders from the syncthing configuration;
                       config location is taken from $STCONFDIR or $STHOMEDIR,
                       then 'syncthing paths', then the platform default
-  -d/--directory DIR  only scan for sync conflicts in the directory DIR
   -f/--find           use find instead of locate; by default, scan the home
                       directory of the current user, but please see the -d
                       option

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ instead, consent is asked for removal:
 syncthing-resolve-conflicts v1.2.0
 
 Inspired by 'pacdiff'. A simple program to merge or remove synchronization
-conflicts. 'locate' (or 'find' or 'fd', see -f and -F options) is used to
-find conflicts. If you are using 'locate', make sure that your database is
+conflicts. 'locate' is used by default to find conflicts; use -f for 'find'
+or -F for 'fd'. If you are using 'locate', make sure your database is
 up-to-date by running 'updatedb'.
 
 Usage: syncthing-resolve-conflicts [-d DIR] [-c] [-f] [-F] [-o] [--nocolor]

--- a/syncthing-resolve-conflicts
+++ b/syncthing-resolve-conflicts
@@ -77,8 +77,8 @@ usage() {
 ${myname} v${myver}
 
 Inspired by 'pacdiff'. A simple program to merge or remove synchronization
-conflicts. 'locate' (or 'find' or 'fd', see -f and -F options) is used to
-find conflicts. If you are using 'locate', make sure that your database is
+conflicts. 'locate' is used by default to find conflicts; use -f for 'find'
+or -F for 'fd'. If you are using 'locate', make sure your database is
 up-to-date by running 'updatedb'.
 
 Usage: $myname [-d DIR] [-c] [-f] [-F] [-o] [--nocolor]

--- a/syncthing-resolve-conflicts
+++ b/syncthing-resolve-conflicts
@@ -81,13 +81,13 @@ conflicts. 'locate' (or 'find' or 'fd', see -f and -F options) is used to
 find conflicts. If you are using 'locate', make sure that your database is
 up-to-date by running 'updatedb'.
 
-Usage: $myname [-c] [-d DIR] [-f] [-F] [-o] [--nocolor]
+Usage: $myname [-d DIR] [-c] [-f] [-F] [-o] [--nocolor]
 
 General Options:
+  -d/--directory DIR  only scan for sync conflicts in the directory DIR
   -c/--config         scan all folders from the syncthing configuration;
                       config location is taken from \$STCONFDIR or \$STHOMEDIR,
                       then 'syncthing paths', then the platform default
-  -d/--directory DIR  only scan for sync conflicts in the directory DIR
   -f/--find           use find instead of locate; by default, scan the home
                       directory of the current user, but please see the -d
                       option

--- a/syncthing-resolve-conflicts
+++ b/syncthing-resolve-conflicts
@@ -10,8 +10,7 @@ diffprog=${DIFFPROG:-'vim -d'}
 USE_COLOR='y'
 declare findprog="locate"
 declare DIRECTORY=""
-declare -a ignored
-declare -a nontext
+declare USE_SYNCTHING_CONFIG=""
 
 plain() {
     ((QUIET)) && return
@@ -82,9 +81,12 @@ conflicts. 'locate' (or 'find' or 'fd', see -f and -F options) is used to
 find conflicts. If you are using 'locate', make sure that your database is
 up-to-date by running 'updatedb'.
 
-Usage: $myname [-d DIR] [-f] [-F] [-o] [--nocolor]
+Usage: $myname [-c] [-d DIR] [-f] [-F] [-o] [--nocolor]
 
 General Options:
+  -c/--config         scan all folders from the syncthing configuration;
+                      config location is taken from \$STCONFDIR or \$STHOMEDIR,
+                      then 'syncthing paths', then the platform default
   -d/--directory DIR  only scan for sync conflicts in the directory DIR
   -f/--find           use find instead of locate; by default, scan the home
                       directory of the current user, but please see the -d
@@ -153,6 +155,231 @@ check_dir() {
     realpath "$1"
 }
 
+# Returns the path to the syncthing config.xml file, trying in order:
+# $STCONFDIR, $STHOMEDIR, 'syncthing paths', and the platform default.
+find_syncthing_config() {
+    local config_search_paths=()
+
+    [[ -n $STCONFDIR ]] && config_search_paths+=("$STCONFDIR/config.xml")
+    [[ -n $STHOMEDIR ]] && config_search_paths+=("$STHOMEDIR/config.xml")
+
+    if command -v syncthing &>/dev/null; then
+        local syncthing_config
+        syncthing_config=$(syncthing paths 2>/dev/null \
+            | awk '/^Configuration file:/ { getline; gsub(/^\t/, ""); print }')
+        [[ -n $syncthing_config ]] && config_search_paths+=("$syncthing_config")
+    fi
+
+    case "$(uname -s)" in
+        Darwin) config_search_paths+=("$HOME/Library/Application Support/Syncthing/config.xml") ;;
+        *)      config_search_paths+=("$HOME/.config/syncthing/config.xml") ;;
+    esac
+
+    local config
+    for config in "${config_search_paths[@]}"; do
+        [[ -f $config ]] && printf '%s\n' "$config" && return 0
+    done
+
+    return 1
+}
+
+get_syncthing_folders() {
+    grep -oP 'path="\K[^"]+' "$1" | grep -v '^$'
+}
+
+process_conflicts() {
+    local DIRECTORY="$1"
+    local -a ignored
+    local -a nontext
+    local -a recursive
+
+    # See http://mywiki.wooledge.org/BashFAQ/020.
+    while IFS= read -u 3 -r -d '' conflict; do
+        [[ ! -e "$conflict" && ! -L "$conflict" && ! -d "$conflict" ]] && continue
+
+        if ((OUTPUTONLY)); then
+            echo "$conflict"
+            continue
+        fi
+
+        # Ignore backups in '.stversions' folders.
+        if [[ "$conflict" = */.stversions/* ]]; then
+            ignored+=("$conflict")
+            continue
+        fi
+
+        # XXX: Maybe somebody wants to diff special non-text files?
+
+        # Ignore binary files.
+        if file -i "$conflict" | grep -qv text; then
+            nontext+=("$conflict")
+            continue
+        fi
+
+        # XXX: Recursive sync conflicts lead to problems if they are treated in the
+        # wrong order. For now, collect sync conflicts of higher order and treat
+        # them later.
+        if [[ "$conflict" = *sync-conflict*sync-conflict* ]]; then
+            recursive+=("$conflict")
+            continue
+        fi
+
+        # Original filename. TODO: Improve pattern match (digits only).
+        file="${conflict/.sync-conflict-????????-??????-???????/}"
+        # Handle sync conflict.
+        msg "Sync conflict: %s" "$conflict"
+        msg2 "Original file: %s" "$file"
+        if [ ! -f "$file" ]; then
+            warning "Original file not found for conflict %s." "$conflict"
+            ignored+=("$conflict")
+            continue
+        elif test "$conflict" -ef "$file"; then
+            warning "Original file and conflict file point to the same file. Ignoring conflict."
+            continue
+        elif cmp -s "$conflict" "$file"; then
+            msg2 "Files are identical, removing..."
+            plain "$(rm -v "$conflict")"
+            continue
+        else
+            ask "(V)iew, (S)kip, (R)emove sync conflict, (O)verwrite with sync conflict, (Q)uit: [v/s/r/o/q] "
+            # shellcheck disable=SC2162
+            while read c; do
+                case $c in
+                q | Q) exit 0 ;;
+                r | R)
+                    plain "$(rm -v "$conflict")"
+                    break
+                    ;;
+                o | O)
+                    plain "$(mv -v "$conflict" "$file")"
+                    break
+                    ;;
+                v | V)
+                    $diffprog "$conflict" "$file"
+                    ask "(V)iew, (S)kip, (R)emove sync conflict, (O)verwrite with sync conflict, (Q)uit: [v/s/r/o/q] "
+                    continue
+                    ;;
+                s | S) break ;;
+                *)
+                    ask "Invalid answer. Try again: [v/s/r/o/q] "
+                    continue
+                    ;;
+                esac
+            done
+        fi
+    done 3< <(cmd)
+
+    # Print warning if files have been ignored and delete them if specified.
+    if [ ! ${#ignored[@]} -eq 0 ]; then
+        warning "Some files have been ignored."
+        ((${#ignored[@]})) && msg "%s" "${ignored[@]}"
+        ask "(R)emove all ignored files, (A)sk for each file, (Q)uit: [r/q] "
+        # shellcheck disable=SC2162
+        while read c; do
+            case "$c" in
+            q | Q) exit 0 ;;
+            a | A)
+                for f in "${ignored[@]}"; do
+                    msg "Ignored file: %s" "$f"
+                    ask "(R)emove, (S)kip, (Q)uit: [r/s/q] "
+                    # shellcheck disable=SC2162
+                    while read ci; do
+                        case "$ci" in
+                        q | Q) exit 0 ;;
+                        s | S) break ;;
+                        r | R)
+                            plain "$(rm -v "$f")"
+                            break
+                            ;;
+                        *)
+                            ask "Invalid answer.  Try again: [r/s/q] "
+                            continue
+                            ;;
+                        esac
+                    done
+                done
+                ;;
+            r | R)
+                ((${#ignored[@]})) && plain "$(rm -v "${ignored[@]}")"
+                break
+                ;;
+            *)
+                ask "Invalid answer.  Try again: [d/q] "
+                continue
+                ;;
+            esac
+        done
+    fi
+
+    # Print warning if recursive conflicts of depth two or larger have been ignored
+    # and delete them if specified.
+    if [ ! ${#recursive[@]} -eq 0 ]; then
+        warning "Some recursive conflicts have been ignored."
+        ((${#recursive[@]})) && msg "%s" "${recursive[@]}"
+        ask "(R)emove all ignored files, (A)sk for each file, (Q)uit: [r/q] "
+        # shellcheck disable=SC2162
+        while read c; do
+            case "$c" in
+            q | Q) exit 0 ;;
+            a | A)
+                for f in "${recursive[@]}"; do
+                    msg "Ignored file: %s" "$f"
+                    ask "(R)emove, (S)kip, (Q)uit: [r/s/q] "
+                    # shellcheck disable=SC2162
+                    while read ci; do
+                        case "$ci" in
+                        q | Q) exit 0 ;;
+                        s | S) break ;;
+                        r | R)
+                            plain "$(rm -v "$f")"
+                            break
+                            ;;
+                        *)
+                            ask "Invalid answer.  Try again: [r/s/q] "
+                            continue
+                            ;;
+                        esac
+                    done
+                done
+                ;;
+            r | R)
+                ((${#recursive[@]})) && plain "$(rm -v "${recursive[@]}")"
+                break
+                ;;
+            *)
+                ask "Invalid answer.  Try again: [d/q] "
+                continue
+                ;;
+            esac
+        done
+    fi
+
+    # Print warning if non-text sync conflicts have been detected and delete them
+    # one by one if specified.
+    if [ ! ${#nontext[@]} -eq 0 ]; then
+        warning "The following conflicts involve non-text files:"
+        for f in "${nontext[@]}"; do
+            msg "Non-text file: %s" "$f"
+            ask "(R)emove, (S)kip, (Q)uit: [r/s/q] "
+            # shellcheck disable=SC2162
+            while read c; do
+                case "$c" in
+                q | Q) exit 0 ;;
+                s | S) break ;;
+                r | R)
+                    plain "$(rm -v "$f")"
+                    break
+                    ;;
+                *)
+                    ask "Invalid answer.  Try again: [r/s/q] "
+                    continue
+                    ;;
+                esac
+            done
+        done
+    fi
+}
+
 while [[ -n "$1" ]]; do
     case "$1" in
     -h | --help)
@@ -162,6 +389,9 @@ while [[ -n "$1" ]]; do
     -v | -V | --version)
         version
         exit 0
+        ;;
+    -c | --config)
+        USE_SYNCTHING_CONFIG=1
         ;;
     -d | --directory)
         DIRECTORY=$(check_dir "$2")
@@ -186,6 +416,11 @@ while [[ -n "$1" ]]; do
     esac
     shift
 done
+
+if [[ -n $USE_SYNCTHING_CONFIG && -n $DIRECTORY ]]; then
+    error "Options -c and -d are mutually exclusive."
+    exit 1
+fi
 
 # Check if messages are to be printed using color.
 unset ALL_OFF BLUE GREEN RED YELLOW
@@ -232,190 +467,17 @@ if [ -z "$(command -v "${diffprog%% *}")" ] && ((!OUTPUTONLY)); then
     exit 1
 fi
 
-# See http://mywiki.wooledge.org/BashFAQ/020.
-while IFS= read -u 3 -r -d '' conflict; do
-    [[ ! -e "$conflict" && ! -L "$conflict" && ! -d "$conflict" ]] && continue
-
-    if ((OUTPUTONLY)); then
-        echo "$conflict"
-        continue
-    fi
-
-    # Ignore backups in '.stversions' folders.
-    if [[ "$conflict" = */.stversions/* ]]; then
-        ignored+=("$conflict")
-        continue
-    fi
-
-    # XXX: Maybe somebody wants to diff special non-text files?
-
-    # Ignore binary files.
-    if file -i "$conflict" | grep -qv text; then
-        nontext+=("$conflict")
-        continue
-    fi
-
-    # XXX: Recursive sync conflicts lead to problems if they are treated in the
-    # wrong order. For now, collect sync conflicts of higher order and treat
-    # them later.
-    if [[ "$conflict" = *sync-conflict*sync-conflict* ]]; then
-        recursive+=("$conflict")
-        continue
-    fi
-
-    # Original filename. TODO: Improve pattern match (digits only).
-    file="${conflict/.sync-conflict-????????-??????-???????/}"
-    # Handle sync conflict.
-    msg "Sync conflict: %s" "$conflict"
-    msg2 "Original file: %s" "$file"
-    if [ ! -f "$file" ]; then
-        warning "Original file not found for conflict %s." "$conflict"
-        ignored+=("$conflict")
-        continue
-    elif test "$conflict" -ef "$file"; then
-        warning "Original file and conflict file point to the same file. Ignoring conflict."
-        continue
-    elif cmp -s "$conflict" "$file"; then
-        msg2 "Files are identical, removing..."
-        plain "$(rm -v "$conflict")"
-        continue
-    else
-        ask "(V)iew, (S)kip, (R)emove sync conflict, (O)verwrite with sync conflict, (Q)uit: [v/s/r/o/q] "
-        # shellcheck disable=SC2162
-        while read c; do
-            case $c in
-            q | Q) exit 0 ;;
-            r | R)
-                plain "$(rm -v "$conflict")"
-                break
-                ;;
-            o | O)
-                plain "$(mv -v "$conflict" "$file")"
-                break
-                ;;
-            v | V)
-                $diffprog "$conflict" "$file"
-                ask "(V)iew, (S)kip, (R)emove sync conflict, (O)verwrite with sync conflict, (Q)uit: [v/s/r/o/q] "
-                continue
-                ;;
-            s | S) break ;;
-            *)
-                ask "Invalid answer. Try again: [v/s/r/o/q] "
-                continue
-                ;;
-            esac
-        done
-    fi
-done 3< <(cmd)
-
-# Print warning if files have been ignored and delete them if specified.
-if [ ! ${#ignored[@]} -eq 0 ]; then
-    warning "Some files have been ignored."
-    ((${#ignored[@]})) && msg "%s" "${ignored[@]}"
-    ask "(R)emove all ignored files, (A)sk for each file, (Q)uit: [r/q] "
-    # shellcheck disable=SC2162
-    while read c; do
-        case "$c" in
-        q | Q) exit 0 ;;
-        a | A)
-            for f in "${ignored[@]}"; do
-                msg "Ignored file: %s" "$f"
-                ask "(R)emove, (S)kip, (Q)uit: [r/s/q] "
-                # shellcheck disable=SC2162
-                while read ci; do
-                    case "$ci" in
-                    q | Q) exit 0 ;;
-                    s | S) break ;;
-                    r | R)
-                        plain "$(rm -v "$f")"
-                        break
-                        ;;
-                    *)
-                        ask "Invalid answer.  Try again: [r/s/q] "
-                        continue
-                        ;;
-                    esac
-                done
-            done
-            ;;
-        r | R)
-            ((${#ignored[@]})) && plain "$(rm -v "${ignored[@]}")"
-            break
-            ;;
-        *)
-            ask "Invalid answer.  Try again: [d/q] "
-            continue
-            ;;
-        esac
-    done
-fi
-
-# Print warning if recursive conflicts of depth two or larger have been ignored
-# and delete them if specified.
-if [ ! ${#recursive[@]} -eq 0 ]; then
-    warning "Some recursive conflicts have been ignored."
-    ((${#recursive[@]})) && msg "%s" "${recursive[@]}"
-    ask "(R)emove all ignored files, (A)sk for each file, (Q)uit: [r/q] "
-    # shellcheck disable=SC2162
-    while read c; do
-        case "$c" in
-        q | Q) exit 0 ;;
-        a | A)
-            for f in "${recursive[@]}"; do
-                msg "Ignored file: %s" "$f"
-                ask "(R)emove, (S)kip, (Q)uit: [r/s/q] "
-                # shellcheck disable=SC2162
-                while read ci; do
-                    case "$ci" in
-                    q | Q) exit 0 ;;
-                    s | S) break ;;
-                    r | R)
-                        plain "$(rm -v "$f")"
-                        break
-                        ;;
-                    *)
-                        ask "Invalid answer.  Try again: [r/s/q] "
-                        continue
-                        ;;
-                    esac
-                done
-            done
-            ;;
-        r | R)
-            ((${#recursive[@]})) && plain "$(rm -v "${recursive[@]}")"
-            break
-            ;;
-        *)
-            ask "Invalid answer.  Try again: [d/q] "
-            continue
-            ;;
-        esac
-    done
-fi
-
-# Print warning if non-text sync conflicts have been detected and delete them
-# one by one if specified.
-if [ ! ${#nontext[@]} -eq 0 ]; then
-    warning "The following conflicts involve non-text files:"
-    for f in "${nontext[@]}"; do
-        msg "Non-text file: %s" "$f"
-        ask "(R)emove, (S)kip, (Q)uit: [r/s/q] "
-        # shellcheck disable=SC2162
-        while read c; do
-            case "$c" in
-            q | Q) exit 0 ;;
-            s | S) break ;;
-            r | R)
-                plain "$(rm -v "$f")"
-                break
-                ;;
-            *)
-                ask "Invalid answer.  Try again: [r/s/q] "
-                continue
-                ;;
-            esac
-        done
-    done
+if (( USE_SYNCTHING_CONFIG )); then
+    config_file=$(find_syncthing_config) || {
+        error "Could not find a valid syncthing configuration file."
+        msg "Set \$STCONFDIR or \$STHOMEDIR to point to your syncthing configuration directory."
+        exit 1
+    }
+    while IFS= read -r folder; do
+        process_conflicts "$folder"
+    done < <(get_syncthing_folders "$config_file")
+else
+    process_conflicts "$DIRECTORY"
 fi
 
 exit 0

--- a/syncthing-resolve-conflicts
+++ b/syncthing-resolve-conflicts
@@ -10,7 +10,7 @@ diffprog=${DIFFPROG:-'vim -d'}
 USE_COLOR='y'
 declare findprog="locate"
 declare DIRECTORY=""
-declare USE_SYNCTHING_CONFIG=""
+declare -i USE_SYNCTHING_CONFIG=0
 
 plain() {
     ((QUIET)) && return
@@ -172,7 +172,8 @@ find_syncthing_config() {
 
     case "$(uname -s)" in
         Darwin) config_search_paths+=("$HOME/Library/Application Support/Syncthing/config.xml") ;;
-        *)      config_search_paths+=("$HOME/.config/syncthing/config.xml") ;;
+        *)      config_search_paths+=("$HOME/.local/state/syncthing/config.xml")
+                config_search_paths+=("$HOME/.config/syncthing/config.xml") ;;
     esac
 
     local config
@@ -184,7 +185,9 @@ find_syncthing_config() {
 }
 
 get_syncthing_folders() {
-    grep -oP 'path="\K[^"]+' "$1" | grep -v '^$'
+    sed -n 's/.*path="\([^"]*\)".*/\1/p' "$1" | while IFS= read -r folder; do
+        echo "${folder/#\~/$HOME}"
+    done
 }
 
 process_conflicts() {
@@ -417,7 +420,7 @@ while [[ -n "$1" ]]; do
     shift
 done
 
-if [[ -n $USE_SYNCTHING_CONFIG && -n $DIRECTORY ]]; then
+if (( USE_SYNCTHING_CONFIG )) && [[ -n $DIRECTORY ]]; then
     error "Options -c and -d are mutually exclusive."
     exit 1
 fi
@@ -473,9 +476,17 @@ if (( USE_SYNCTHING_CONFIG )); then
         msg "Set \$STCONFDIR or \$STHOMEDIR to point to your syncthing configuration directory."
         exit 1
     }
+    folders=()
     while IFS= read -r folder; do
-        process_conflicts "$folder"
+        folders+=("$folder")
     done < <(get_syncthing_folders "$config_file")
+    if (( ${#folders[@]} == 0 )); then
+        error "No folders found in syncthing configuration."
+        exit 1
+    fi
+    for folder in "${folders[@]}"; do
+        process_conflicts "$folder"
+    done
 else
     process_conflicts "$DIRECTORY"
 fi


### PR DESCRIPTION
Closes dschrempf/syncthing-resolve-conflicts#11

Adds a `-c`/`--config` flag that reads all folder paths from the syncthing `config.xml` and processes them sequentially.

The config file is searched in this order:
1. `$STCONFDIR/config.xml`
2. `$STHOMEDIR/config.xml`
3. `syncthing paths` (if `syncthing` is installed and in `$PATH`)
4. Platform default (`~/.config/syncthing/config.xml` on Linux,
   `~/Library/Application Support/Syncthing/config.xml` on macOS)

`-c` and `-d` are mutually exclusive. `-c` is compatible with `-f`/`-F`.

**Notes:**
- The main conflict-processing logic was moved into a `process_conflicts()` function to allow looping over multiple directories. This causes a large diff (indentation).
- README updated to reflect the new option.